### PR TITLE
Update OpenAPI 3.0 logic for getting responses

### DIFF
--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -22,7 +22,7 @@ const common = require('./common.js');
 
 let templates;
 
-function convertToToc(source,data) {
+function convertToToc(source, data) {
     let resources = {};
     resources[data.translations.defaultTag] = { count: 0, methods: {} };
     if (source.tags) {
@@ -52,7 +52,7 @@ function convertToToc(source,data) {
                     tagDescription = tagData.description;
                 }
                 if (!resources[tagName]) {
-                    resources[tagName] = { count: 0, methods: {}, description: tagDescription};
+                    resources[tagName] = { count: 0, methods: {}, description: tagDescription };
                 }
                 resources[tagName].count++;
                 resources[tagName].methods[sMethodUniqueName] = method;
@@ -65,15 +65,15 @@ function convertToToc(source,data) {
     return resources;
 }
 
-function getTagGroup(tag, tagGroups){
+function getTagGroup(tag, tagGroups) {
     if (tagGroups) {
         for (let group of tagGroups) {
             if (group.tags.indexOf(tag) > -1) {
-                return {name: group.title, description: group.description};
+                return { name: group.title, description: group.description };
             }
         }
     }
-    return {name: tag, description: ''};
+    return { name: tag, description: '' };
 }
 
 function fakeProdCons(data) {
@@ -99,11 +99,11 @@ function fakeProdCons(data) {
                 if (op.requestBody.content[rb].schema) {
                     let schema = op.requestBody.content[rb].schema;
                     if (schema['x-widdershins-oldRef']) {
-                        data.bodyParameter.refName = schema['x-widdershins-oldRef'].replace('#/components/schemas/','');
+                        data.bodyParameter.refName = schema['x-widdershins-oldRef'].replace('#/components/schemas/', '');
                     }
                     else {
                         if ((schema.type === 'array') && (schema.items) && (schema.items['x-widdershins-oldRef'])) {
-                            data.bodyParameter.refName = schema.items['x-widdershins-oldRef'].replace('#/components/schemas/','');
+                            data.bodyParameter.refName = schema.items['x-widdershins-oldRef'].replace('#/components/schemas/', '');
                         }
 
                     }
@@ -115,10 +115,10 @@ function fakeProdCons(data) {
                     data.bodyParameter.exampleValues.description = op.requestBody.content[rb].examples[key].description;
                 }
                 else {
-                    data.bodyParameter.exampleValues.object = common.getSample(op.requestBody.content[rb].schema,data.options,{skipReadOnly:true,quiet:true},data.api);
+                    data.bodyParameter.exampleValues.object = common.getSample(op.requestBody.content[rb].schema, data.options, { skipReadOnly: true, quiet: true }, data.api);
                 }
                 if (typeof data.bodyParameter.exampleValues.object === 'object') {
-                    data.bodyParameter.exampleValues.json = safejson(data.bodyParameter.exampleValues.object,null,2);
+                    data.bodyParameter.exampleValues.json = safejson(data.bodyParameter.exampleValues.object, null, 2);
                 }
                 else {
                     data.bodyParameter.exampleValues.json = data.bodyParameter.exampleValues.object;
@@ -182,28 +182,28 @@ function getParameters(data) {
             param.originalType = pSchema.type;
             param.safeType = pSchema.type || common.inferType(pSchema);
             if (pSchema.format) {
-                param.safeType = param.safeType+'('+pSchema.format+')';
+                param.safeType = param.safeType + '(' + pSchema.format + ')';
             }
             if ((param.safeType === 'array') && (pSchema.items)) {
                 let itemsType = pSchema.items.type;
                 if (!itemsType) {
                     itemsType = common.inferType(pSchema.items);
                 }
-                param.safeType = 'array['+itemsType+']';
+                param.safeType = 'array[' + itemsType + ']';
             }
             if (pSchema["x-widdershins-oldRef"]) {
-                let schemaName = pSchema["x-widdershins-oldRef"].replace('#/components/schemas/','');
-                param.safeType = '['+schemaName+'](#schema'+schemaName.toLowerCase()+')';
+                let schemaName = pSchema["x-widdershins-oldRef"].replace('#/components/schemas/', '');
+                param.safeType = '[' + schemaName + '](#schema' + schemaName.toLowerCase() + ')';
             }
-            if (param.refName) param.safeType = '['+param.refName+'](#schema'+param.refName.toLowerCase()+')';
+            if (param.refName) param.safeType = '[' + param.refName + '](#schema' + param.refName.toLowerCase() + ')';
         }
         if (pSchema) {
-            param.exampleValues.object = param.example || param.default || common.getSample(pSchema,data.options,{skipReadOnly:true,quiet:true},data.api);
+            param.exampleValues.object = param.example || param.default || common.getSample(pSchema, data.options, { skipReadOnly: true, quiet: true }, data.api);
             if (typeof param.exampleValues.object === 'object') {
-                param.exampleValues.json = safejson(param.exampleValues.object,null,2);
+                param.exampleValues.json = safejson(param.exampleValues.object, null, 2);
             }
             else {
-                param.exampleValues.json = "'"+param.exampleValues.object+"'";
+                param.exampleValues.json = "'" + param.exampleValues.object + "'";
             }
         }
         if (param.description === 'undefined') { // yes, the string
@@ -231,8 +231,8 @@ function getParameters(data) {
             if (param.style === 'matrix') template += ';';
             template += stupidity(param.name);
             template += param.explode ? '*}' : '}';
-            uriTemplateStr = uriTemplateStr.split('{'+param.name+'}').join(template);
-            requiredUriTemplateStr = requiredUriTemplateStr.split('{'+param.name+'}').join(template);
+            uriTemplateStr = uriTemplateStr.split('{' + param.name + '}').join(template);
+            requiredUriTemplateStr = requiredUriTemplateStr.split('{' + param.name + '}').join(template);
         }
         if (param.in === 'query') {
             let isFirst = uriTemplateStr.indexOf('{&') < 0;
@@ -256,7 +256,7 @@ function getParameters(data) {
     }
 
     let effSecurity;
-    let existingAuth = data.allHeaders.find(function(e,i,a){
+    let existingAuth = data.allHeaders.find(function (e, i, a) {
         return e.name.toLowerCase() === 'authorization';
     });
     if (data.operation.security) {
@@ -328,7 +328,7 @@ function getBodyParameterExamples(data) {
     }
     if (common.doContentType(data.consumes, 'json')) {
         content += '```json\n';
-        content += safejson(obj,null,2) + '\n';
+        content += safejson(obj, null, 2) + '\n';
         content += '```\n\n';
     }
     if (common.doContentType(data.consumes, 'yaml')) {
@@ -376,12 +376,12 @@ function fakeBodyParameter(data) {
         }
         param.refName = data.bodyParameter.refName;
         if (!data.options.omitBody || param.schema["x-widdershins-oldRef"]) {
-           bodyParams.push(param);
+            bodyParams.push(param);
         }
 
         if ((param.schema.type === 'object') && (data.options.expandBody || (!param.schema["x-widdershins-oldRef"]))) {
             let offset = (data.options.omitBody ? -1 : 0);
-            let props = common.schemaToArray(data.bodyParameter.schema,offset,{trim:true},data);
+            let props = common.schemaToArray(data.bodyParameter.schema, offset, { trim: true }, data);
 
             for (let block of props) {
                 for (let prop of block.rows) {
@@ -407,8 +407,8 @@ function fakeBodyParameter(data) {
 
 function mergePathParameters(data) {
     if (!data.parameters) data.parameters = [];
-    data.parameters = data.parameters.concat(data.method.pathParameters||[]);
-    data.parameters = data.parameters.filter((param, index, self) => self.findIndex((p) => {return p.name === param.name && p.in === param.in; }) === index || param.in === 'body');
+    data.parameters = data.parameters.concat(data.method.pathParameters || []);
+    data.parameters = data.parameters.filter((param, index, self) => self.findIndex((p) => { return p.name === param.name && p.in === param.in; }) === index || param.in === 'body');
 }
 
 function getResponses(data) {
@@ -446,11 +446,13 @@ function getResponses(data) {
                 if (contentType.schema && contentType.schema.properties && contentType.schema.properties.data && !contentType.schema.properties.template) {
                     if (contentType.schema.properties.data.items) {
                         schemaName = contentType.schema.properties.data.items["x-widdershins-oldRef"].replace('#/components/schemas/', '');
-                    } else {
+                    } else if (contentType.schema.properties.data["x-widdershins-oldRef"]) {
                         schemaName = contentType.schema.properties.data["x-widdershins-oldRef"].replace('#/components/schemas/', '');
+                    } else {
+                        schemaName = contentType.schema["x-widdershins-oldRef"].replace('#/components/schemas/', '');
                     }
                 } else {
-                    schemaName = contentType.schema["x-widdershins-oldRef"].replace('#/components/schemas/','');
+                    schemaName = contentType.schema["x-widdershins-oldRef"].replace('#/components/schemas/', '');
                 }
 
                 if (data.api.info["x-docs-schema-whitelist"].includes(schemaName.replaceAll('[', '').replaceAll(']', ''))) {
@@ -496,18 +498,18 @@ function getResponseExamples(data) {
             if (contentType.examples) {
                 for (let ctei in contentType.examples) {
                     let example = contentType.examples[ctei];
-                    examples.push({description:example.description||response.description,value: common.clean(convertExample(example.value)), cta: cta});
+                    examples.push({ description: example.description || response.description, value: common.clean(convertExample(example.value)), cta: cta });
                 }
             }
             else if (contentType.example) {
-                examples.push({description:resp+' '+data.translations.response,value:common.clean(convertExample(contentType.example)), cta: cta});
+                examples.push({ description: resp + ' ' + data.translations.response, value: common.clean(convertExample(contentType.example)), cta: cta });
             }
             else if (contentType.schema) {
                 let obj = contentType.schema;
                 let autoCT = '';
                 if (common.doContentType(cta, 'json')) autoCT = 'json';
                 if (common.doContentType(cta, 'yaml')) autoCT = 'yaml';
-                if (common.doContentType(cta, 'xml'))  autoCT = 'xml';
+                if (common.doContentType(cta, 'xml')) autoCT = 'xml';
                 if (common.doContentType(cta, 'text')) autoCT = 'text';
 
                 if (!autoDone[autoCT]) {
@@ -519,7 +521,7 @@ function getResponseExamples(data) {
                     else if (obj["x-widdershins-oldRef"]) {
                         xmlWrap = obj["x-widdershins-oldRef"].split('/').pop();
                     }
-                    examples.push({description:resp+' '+data.translations.response,value:common.getSample(obj,data.options,{skipWriteOnly:true,quiet:true},data.api), cta: cta, xmlWrap: xmlWrap});
+                    examples.push({ description: resp + ' ' + data.translations.response, value: common.getSample(obj, data.options, { skipWriteOnly: true, quiet: true }, data.api), cta: cta, xmlWrap: xmlWrap });
                 }
             }
         }
@@ -527,7 +529,7 @@ function getResponseExamples(data) {
     let lastDesc = '';
     for (let example of examples) {
         if (example.description && example.description !== lastDesc) {
-            content += '> '+example.description+'\n\n';
+            content += '> ' + example.description + '\n\n';
             lastDesc = example.description;
         }
         if (common.doContentType(example.cta, 'json')) {
@@ -594,7 +596,7 @@ function getAuthenticationStr(data) {
             list += (list ? sep : '') + (secDef ? secName : data.translations.secDefNone);
             let scopes = data.security[s][secName];
             if (Array.isArray(scopes) && (scopes.length > 0)) {
-                list += ' ( '+data.translations.secDefScopes+': ';
+                list += ' ( ' + data.translations.secDefScopes + ': ';
                 for (let scope in scopes) {
                     list += scopes[scope] + ' ';
                 }
@@ -618,19 +620,19 @@ function convertInner(api, options, callback) {
     defaults.search = true;
     defaults.theme = 'darkula';
     defaults.headings = 2;
-    defaults.templateCallback = function(template,stage,data) { return data; };
+    defaults.templateCallback = function (template, stage, data) { return data; };
 
-    options = Object.assign({},defaults,options);
+    options = Object.assign({}, defaults, options);
 
     let data = {};
-    if (options.verbose) console.warn('starting deref',api.info.title);
+    if (options.verbose) console.warn('starting deref', api.info.title);
     if (api.components) {
         data.components = clone(api.components);
     }
     else {
         data.components = {};
     }
-    data.api = dereference(api,api,{verbose:options.verbose,$ref:'x-widdershins-oldRef'});
+    data.api = dereference(api, api, { verbose: options.verbose, $ref: 'x-widdershins-oldRef' });
     if (options.verbose) console.warn('finished deref');
 
     if (data.api.components && data.api.components.schemas && data.api.components.schemas["x-widdershins-oldRef"]) {
@@ -647,10 +649,10 @@ function convertInner(api, options, callback) {
     data.translations = {};
     templates.translations(data);
 
-    data.version = (data.api.info && data.api.info.version && typeof data.api.info.version === 'string' && data.api.info.version.toLowerCase().startsWith('v') ? data.api.info.version : 'v'+(data.api.info ? data.api.info.version : 'v1.0.0'));
+    data.version = (data.api.info && data.api.info.version && typeof data.api.info.version === 'string' && data.api.info.version.toLowerCase().startsWith('v') ? data.api.info.version : 'v' + (data.api.info ? data.api.info.version : 'v1.0.0'));
 
     let header = {};
-    header.title = api.info && (api.info.title||'API') + ' ' + data.version;
+    header.title = api.info && (api.info.title || 'API') + ' ' + data.version;
     header.language_tabs = options.language_tabs;
     header.toc_footers = [];
     if (api.externalDocs) {
@@ -658,7 +660,7 @@ function convertInner(api, options, callback) {
             header.toc_footers.push('<a href="' + api.externalDocs.url + '">' + (api.externalDocs.description ? api.externalDocs.description : data.translations.externalDocs) + '</a>');
         }
     }
-    if (options.toc_footers)  {
+    if (options.toc_footers) {
         for (var key in options.toc_footers) {
             header.toc_footers.push('<a href="' + options.toc_footers[key].url + '">' + options.toc_footers[key].description + '</a>');
         }
@@ -669,22 +671,22 @@ function convertInner(api, options, callback) {
     header.headingLevel = options.headings;
 
     data.header = header;
-    data.title_prefix = (data.api.info && data.api.info.version ? common.slugify(data.api.info.title.trim()||'API') : '');
+    data.title_prefix = (data.api.info && data.api.info.version ? common.slugify(data.api.info.title.trim() || 'API') : '');
     data.templates = templates;
-    data.resources = convertToToc(api,data);
+    data.resources = convertToToc(api, data);
 
     if (data.api.servers && data.api.servers.length) {
         data.servers = data.api.servers;
     }
     else if (options.loadedFrom) {
-        data.servers = [{url:options.loadedFrom}];
+        data.servers = [{ url: options.loadedFrom }];
     }
     else {
-        data.servers = [{url:'//'}];
+        data.servers = [{ url: '//' }];
     }
     data.host = up.parse(data.servers[0].url).host;
     data.protocol = up.parse(data.servers[0].url).protocol;
-    if (data.protocol) data.protocol = data.protocol.replace(':','');
+    if (data.protocol) data.protocol = data.protocol.replace(':', '');
     data.baseUrl = data.servers[0].url;
 
     data.operationStack = [];
@@ -693,9 +695,9 @@ function convertInner(api, options, callback) {
     data.utils.yaml = yaml;
     data.utils.inspect = util.inspect;
     data.utils.safejson = safejson;
-    data.utils.isPrimitive = function(t) { return (t && (t !== 'object') && (t !== 'array')) };
+    data.utils.isPrimitive = function (t) { return (t && (t !== 'object') && (t !== 'array')) };
     data.utils.toPrimitive = common.toPrimitive;
-    data.utils.slashes = function(s) { return s.replace(/\/+/g, '/').replace(':/','://'); };
+    data.utils.slashes = function (s) { return s.replace(/\/+/g, '/').replace(':/', '://'); };
     data.utils.slugify = common.slugify;
     data.utils.getSample = common.getSample;
     data.utils.schemaToArray = common.schemaToArray;
@@ -710,12 +712,12 @@ function convertInner(api, options, callback) {
     data.utils.getResponseHeaders = getResponseHeaders;
     data.utils.getAuthenticationStr = getAuthenticationStr;
     data.widdershins = require('../package.json');
-    data.utils.join = function(s) {
+    data.utils.join = function (s) {
         return s.split('\r').join('').split('\n').join(' ').trim();
     };
 
     let content = '';
-    if (!options.omitHeader) content += '---\n'+yaml.stringify(header)+'\n---\n\n';
+    if (!options.omitHeader) content += '---\n' + yaml.stringify(header) + '\n---\n\n';
     data = options.templateCallback('main', 'pre', data);
     if (data.append) { content += data.append; delete data.append; }
     try {
@@ -728,9 +730,9 @@ function convertInner(api, options, callback) {
     if (data.append) { content += data.append; delete data.append; }
     content = common.removeDupeBlankLines(content);
 
-    if (options.html) content = common.html(content,header,options);
+    if (options.html) content = common.html(content, header, options);
 
-    callback(null,content);
+    callback(null, content);
 }
 
 function convert(api, options, callback) {
@@ -824,7 +826,7 @@ function sort(schema) {
             continue;
         }
 
-        result.push({key: key, value: schema[key]});
+        result.push({ key: key, value: schema[key] });
         delete schema[key];
     }
 
@@ -841,7 +843,7 @@ function sort(schema) {
         if (insertAfter !== undefined) {
             let value = result.splice(i, 1);
             if (insertAfter) {
-                let index = result.findIndex((element) => {return element.key === insertAfter}) + 1;
+                let index = result.findIndex((element) => { return element.key === insertAfter }) + 1;
                 result.splice(index, 0, value[0]);
             } else {
                 result.splice(0, 0, value[0]);
@@ -868,10 +870,10 @@ function mergeDeep(target, ...sources) {
         for (const key in source) {
             if (source.hasOwnProperty(key)) {
                 if (isObject(source[key])) {
-                    if (!target[key]) Object.assign(target, {[key]: {}});
+                    if (!target[key]) Object.assign(target, { [key]: {} });
                     mergeDeep(target[key], source[key]);
                 } else {
-                    Object.assign(target, {[key]: source[key]});
+                    Object.assign(target, { [key]: source[key] });
                 }
             }
         }
@@ -881,6 +883,6 @@ function mergeDeep(target, ...sources) {
 }
 
 module.exports = {
-    convert : convert,
+    convert: convert,
     fakeBodyParameter: fakeBodyParameter
 };


### PR DESCRIPTION
Previously, App Components docs couldn't be built (i.e., using `make app_components_docs_gen` in [developer-docs](https://github.com/Asana/developer-docs)) if a `data` property existed in the response. Specifically, `.replace()` would be called on an `undefined` resource. This PR fixes that.

I've also linted the file for better readability in the future.